### PR TITLE
Fix Sliderbreak counter not resetting

### DIFF
--- a/memory/functions.go
+++ b/memory/functions.go
@@ -32,6 +32,9 @@ var isTournamentMode bool
 var tourneyProcs []mem.Process
 var tourneyErr error
 
+//Were we in the Result Screen?
+var dirtyResults bool = false
+
 //var proc, procerr = kiwi.GetProcessByFileName("osu!.exe")
 var leaderStart int32
 
@@ -107,7 +110,7 @@ func Init() {
 						pp.Println(err)
 					}
 				}
-				if gameplayData.Retries > tempRetries {
+				if gameplayData.Retries > tempRetries || dirtyResults {
 					tempRetries = gameplayData.Retries
 					GameplayData = GameplayValues{}
 					gameplayData = gameplayD{}
@@ -150,6 +153,9 @@ func Init() {
 					ResultsScreenData.Mods.PpMods = "NM"
 				} else {
 					ResultsScreenData.Mods.PpMods = Mods(resultsScreenData.ModsXor1 ^ resultsScreenData.ModsXor2).String()
+				}
+				if !dirtyResults {
+					dirtyResults=true
 				}
 			default:
 				tempRetries = -1

--- a/memory/functions.go
+++ b/memory/functions.go
@@ -114,7 +114,7 @@ func Init() {
 					tempRetries = gameplayData.Retries
 					GameplayData = GameplayValues{}
 					gameplayData = gameplayD{}
-
+					dirtyResults = false
 				}
 				getGamplayData()
 			case 1:


### PR DESCRIPTION
This is better than #59, because this does not add a check, when playing. It only adds a or to an already in place check, which determines, if the SB counter should be rest. This is also cleaner, than #59, because the whole gameplay score object is wiped.
This should not noticably affect performance.
NOTE: This is my first time coding Go. I don't know, if this is compilable, but it should follow the Go syntax.