### PR TITLE
Providing current position of cursor while playing & Optimize key status

### DIFF
--- a/memory/functions.go
+++ b/memory/functions.go
@@ -20,25 +20,25 @@ func modsResolver(xor uint32) string {
 	return Mods(xor).String()
 }
 
-//UpdateTime Intervall between value updates
+// UpdateTime Intervall between value updates
 var UpdateTime int
 
-//UnderWine?
+// UnderWine?
 var UnderWine bool
 
-//MemCycle test
+// MemCycle test
 var MemCycle bool
 var isTournamentMode bool
 var tourneyProcs []mem.Process
 var tourneyErr error
 
-//Were we in the Result Screen?
+// Were we in the Result Screen?
 var dirtyResults bool = false
 
-//var proc, procerr = kiwi.GetProcessByFileName("osu!.exe")
+// var proc, procerr = kiwi.GetProcessByFileName("osu!.exe")
 var leaderStart int32
 
-//SongsFolderPath is full path to osu! Songs. Gets set automatically on Windows (through memory)
+// SongsFolderPath is full path to osu! Songs. Gets set automatically on Windows (through memory)
 var SongsFolderPath string
 
 var allProcs []mem.Process
@@ -46,7 +46,113 @@ var process mem.Process
 var procerr error
 var tempRetries int32
 
-//Init the whole thing and get osu! memory values to start working with it.
+// Hit events
+var hitEventBaseAddress struct {
+	Playing int32
+	Replay  int32
+}
+
+var hitEventPreOffset [4]int32 = [4]int32{-1, -1, -1, -1}
+var hitEventAddress [5]int32 = [5]int32{0, 0, 0, 0, 0}
+var hitEventIndexIncrement int32 = 0
+var prePlayTime int32 = 2147483647
+var preStatus uint32 = 100
+var hitEventFrame []hitEvent
+var currentHitEventFrameIndex int
+var prevHitEventFrameSize int = 0
+
+func getHitEventOffset(depth int32, index int32) int32 {
+	switch depth {
+	case 0:
+		return 0x34
+	case 1:
+		return 0x4
+	case 2:
+		return 0x8 + index*0x4
+	case 3:
+		return 0
+	default:
+		return -1 // this should not happen
+	}
+}
+
+type addrWithMask struct {
+	string
+	int
+}
+
+func resolveHitEventAddress() error {
+	var _hitEventMemPatterns struct {
+		Playing []addrWithMask
+		Replay  []addrWithMask
+	} = struct {
+		Playing []addrWithMask
+		Replay  []addrWithMask
+	}{ // hit event addr may have different pattern
+		[]addrWithMask{
+			{"83 7E 60 00 74 2C A1 ?? ?? ?? ?? 8B 50 1C 8B 4A 04", 7},
+			{"5D C3 A1 ?? ?? ?? ?? 8B 50 1C 8B 4A 04", 3},
+		},
+		[]addrWithMask{
+			{"D9 5D C0 EB 4E A1 ?? ?? ?? ?? 8B 48 34 4E", 6},
+			{"74 4D A1 ?? ?? ?? ?? 8B 58 34 8D 46 FF", 3},
+			{"A1 ?? ?? ?? ?? 8B 40 34 8B 70 0C", 1},
+			{"75 0E 33 D2 89 15 ?? ?? ?? ?? 89 15", 6},
+		},
+	}
+
+	if hitEventBaseAddress.Playing == 0 {
+		var errMsg string = ""
+		var resolved = false
+		for i, t := range _hitEventMemPatterns.Playing {
+			base, err := mem.Scan(process, t.string)
+			if err != nil || base == 0 {
+				errMsg += err.Error() + "; "
+				continue
+			}
+			addr, err := mem.ReadInt32(process, base, int64(t.int))
+			if err != nil || addr == 0 {
+				errMsg += err.Error() + "; "
+				continue
+			} else {
+				hitEventBaseAddress.Playing = addr
+				resolved = true
+				log.Printf("Resolved hit event(playing) at 0x%x by pattern #%d.\n", addr, i)
+				break
+			}
+		}
+		if !resolved {
+			return fmt.Errorf("err resolving hit event(playing) address: %s", errMsg)
+		}
+	}
+	if hitEventBaseAddress.Replay == 0 {
+		var errMsg string = ""
+		var resolved = false
+		for i, t := range _hitEventMemPatterns.Replay {
+			base, err := mem.Scan(process, t.string)
+			if err != nil || base == 0 {
+				errMsg += err.Error() + "; "
+				continue
+			}
+			addr, err := mem.ReadInt32(process, base, int64(t.int))
+			if err != nil || addr == 0 {
+				errMsg += err.Error() + "; "
+				continue
+			} else {
+				hitEventBaseAddress.Replay = addr
+				resolved = true
+				log.Printf("Resolved hit event(replay) at 0x%x by pattern #%d.\n", addr, i)
+				break
+			}
+		}
+		if !resolved {
+			return fmt.Errorf("err resolving hit event(replay) address: %s", errMsg)
+		}
+	}
+	return nil
+}
+
+// Init the whole thing and get osu! memory values to start working with it.
 func Init() {
 	if UnderWine == true || runtime.GOOS != "windows" { //Arrays start at 0xC in Linux for some reason, has to be wine specific
 		leaderStart = 0xC
@@ -95,6 +201,18 @@ func Init() {
 			SettingsData.Folders.Skin = alwaysData.SkinFolder
 
 			SettingsData.ShowInterface = cast.ToBool(int(alwaysData.ShowInterface))
+
+			resolveHitEventAddress()
+
+			if preStatus == 2 && menuData.Status != 2 {
+				hitEventIndexIncrement = 0
+				preStatus = menuData.Status
+				hitEventFrame = []hitEvent{}
+				currentHitEventFrameIndex = 0
+				prevHitEventFrameSize = 0
+				GameplayData.HitEvent = []hitEvent{}
+			}
+
 			switch menuData.Status {
 			case 0:
 				err = bmUpdateData()
@@ -295,6 +413,111 @@ func getGamplayData() {
 	}
 	getLeaderboard()
 	getKeyOveraly()
+
+	if preStatus != 2 || prePlayTime > alwaysData.PlayTime {
+		hitEventIndexIncrement = 0
+	}
+
+	preStatus = menuData.Status
+	prePlayTime = alwaysData.PlayTime
+
+	if menuData.Status == 2 {
+		if hitEventBaseAddress.Playing != 0 {
+			var currPlayTime = alwaysData.PlayTime
+
+			hitEventAddress[0] = hitEventBaseAddress.Playing
+			getHitEvent()
+
+			var currHitEventFrameSize = len(hitEventFrame)
+			if prevHitEventFrameSize != currHitEventFrameSize {
+				if currHitEventFrameSize == 1 {
+					GameplayData.HitEvent = hitEventFrame
+				} else {
+					GameplayData.HitEvent = hitEventFrame[cast.ToInt(math.Max(cast.ToFloat64(prevHitEventFrameSize-1), 0)):currHitEventFrameSize]
+				}
+			} else {
+				for i := currentHitEventFrameIndex; i < len(hitEventFrame)-1; i++ {
+					var currHitEventFrame = hitEventFrame[i]
+					if currPlayTime > currHitEventFrame.TimeStamp && currPlayTime <= hitEventFrame[i+1].TimeStamp {
+						GameplayData.HitEvent = hitEventFrame[currentHitEventFrameIndex : i+1]
+						currentHitEventFrameIndex = i
+						break
+					}
+				}
+			}
+			prevHitEventFrameSize = currHitEventFrameSize
+		}
+	}
+}
+
+func getHitEvent() {
+	hitEventPreOffset = [4]int32{-1, -1, -1, -1}
+	for {
+		hitEvent, err := readCurrentHitEvent(hitEventIndexIncrement)
+
+		if err != nil || hitEvent.X == -1 {
+			break
+		} else {
+			hitEventFrame = append(hitEventFrame, hitEvent)
+			hitEventIndexIncrement++
+		}
+	}
+}
+
+func readCurrentHitEvent(index int32) (hitEvent, error) {
+	var changed = false
+	var hitEvent hitEvent
+
+	for depth := 0; depth < 4; depth++ {
+		offset := getHitEventOffset(int32(depth), index)
+		if offset != hitEventPreOffset[depth] || changed {
+			hitEventPreOffset[depth] = offset
+			changed = true
+			addr, err := mem.ReadInt32(process, cast.ToInt64(hitEventAddress[depth]))
+			hitEventAddress[depth+1] = addr
+			if err != nil || hitEventAddress[depth+1] == 0 {
+				hitEvent.X = -1
+				return hitEvent, err
+			}
+			hitEventAddress[depth+1] += offset
+		}
+	}
+
+	addr4x64 := cast.ToInt64(hitEventAddress[4])
+
+	x, err := mem.ReadFloat32(process, addr4x64, 4)
+	if err != nil {
+		return hitEvent, err
+	}
+	y, err := mem.ReadFloat32(process, addr4x64, 8)
+	if err != nil {
+		return hitEvent, err
+	}
+	keyBit, err := mem.ReadUint8(process, addr4x64, 12)
+	if err != nil {
+		return hitEvent, err
+	}
+	time, err := mem.ReadInt32(process, addr4x64, 16)
+	if err != nil {
+		return hitEvent, err
+	}
+
+	// print memory
+	// var u8Arr []string = []string{}
+	// for i := 0; i < 100; i++ {
+	// 	u8, _ := mem.ReadUint8(process, addr4x64, int64(i))
+	// 	u8Arr = append(u8Arr, fmt.Sprintf("%2x", u8))
+	// }
+	// fmt.Println(strings.Join(u8Arr, " "))
+
+	hitEvent.X = x
+	hitEvent.Y = y
+	hitEvent.TimeStamp = time
+	hitEvent.K1 = keyBit&0b0101 == 0b0101
+	hitEvent.K2 = keyBit&0b1010 == 0b1010
+	hitEvent.M1 = (keyBit&0b1100 == 0b0000) && ((keyBit&0b0001 == 0b0001) || (keyBit&0b0001 == 0b0011))
+	hitEvent.M2 = (keyBit&0b1100 == 0b0000) && ((keyBit&0b0010 == 0b0010) || (keyBit&0b0010 == 0b0011))
+	return hitEvent, nil
 }
 
 func getLeaderboard() {
@@ -431,29 +654,22 @@ func calculateBassDensity(base uint32, proc *mem.Process) float64 {
 func getKeyOveraly() {
 	addresses := struct{ Base int64 }{int64(gameplayData.KeyOverlayArrayAddr)}
 	var entries struct {
-		K1Pressed int8  `mem:"[Base + 0x8] + 0x1C"` //Pressed usually works with <20 update rate. It's recommended to create a buffer and predict presses by count to save CPU overhead
-		K1Count   int32 `mem:"[Base + 0x8] + 0x14"`
-		K2Pressed int8  `mem:"[Base + 0xC] + 0x1C"`
-		K2Count   int32 `mem:"[Base + 0xC] + 0x14"`
-		M1Pressed int8  `mem:"[Base + 0x10] + 0x1C"`
-		M1Count   int32 `mem:"[Base + 0x10] + 0x14"`
-		M2Pressed int8  `mem:"[Base + 0x14] + 0x1C"`
-		M2Count   int32 `mem:"[Base + 0x14] + 0x14"`
+		//Pressed usually works with <20 update rate. It's recommended to create a buffer and predict presses by count to save CPU overhead
+		K1Count int32 `mem:"[Base + 0x8] + 0x14"`
+		K2Count int32 `mem:"[Base + 0xC] + 0x14"`
+		M1Count int32 `mem:"[Base + 0x10] + 0x14"`
+		M2Count int32 `mem:"[Base + 0x14] + 0x14"`
 	}
 	err := mem.Read(process, &addresses, &entries)
 	if err != nil {
 		return
 	}
 
-	var out keyOverlay
+	var out keyCount
 
-	out.K1.IsPressed = cast.ToBool(int(entries.K1Pressed))
-	out.K1.Count = entries.K1Count
-	out.K2.IsPressed = cast.ToBool(int(entries.K2Pressed))
-	out.K2.Count = entries.K2Count
-	out.M1.IsPressed = cast.ToBool(int(entries.M1Pressed))
-	out.M1.Count = entries.M1Count
-	out.M2.IsPressed = cast.ToBool(int(entries.M2Pressed))
-	out.M2.Count = entries.M2Count
-	GameplayData.KeyOverlay = out //needs complete rewrite in 1.4.0
+	out.K1 = entries.K1Count
+	out.K2 = entries.K2Count
+	out.M1 = entries.M1Count
+	out.M2 = entries.M2Count
+	GameplayData.KeyCount = out //needs complete rewrite in 1.4.0
 }

--- a/memory/init.go
+++ b/memory/init.go
@@ -142,6 +142,12 @@ func initBase() error {
 	fmt.Println("WARNING: Mania pp calcualtion is experimental and only works if you choose mania gamemode in the SongSelect!")
 	fmt.Println(fmt.Sprintf("Initialization complete, you can now visit http://%s or add it as a browser source in OBS", config.Config["serverip"]))
 	DynamicAddresses.IsReady = true
+
+	hitEventBaseAddress = struct {
+		Playing int32
+		Replay  int32
+	}{0, 0}
+
 	if cast.ToBool(config.Config["enabled"]) {
 		err = injctr.Injct(process.Pid())
 		if err != nil {

--- a/memory/values.go
+++ b/memory/values.go
@@ -128,20 +128,26 @@ type GameplayValues struct {
 	Hp          hp          `json:"hp"`
 	Hits        hits        `json:"hits"`
 	PP          ppG         `json:"pp"`
-	KeyOverlay  keyOverlay  `json:"keyOverlay"`
+	KeyCount    keyCount    `json:"keyCount"`
+	HitEvent    []hitEvent  `json:"hitEvents"`
 	Leaderboard leaderboard `json:"leaderboard"`
 }
 
-type keyOverlay struct {
-	K1 keyOverlayButton `json:"k1"`
-	K2 keyOverlayButton `json:"k2"`
-	M1 keyOverlayButton `json:"m1"`
-	M2 keyOverlayButton `json:"m2"`
+type hitEvent struct {
+	X         float32 `json:"x"`
+	Y         float32 `json:"y"`
+	TimeStamp int32   `json:"timeStamp"`
+	K1        bool    `json:"k1"`
+	K2        bool    `json:"k2"`
+	M1        bool    `json:"m1"`
+	M2        bool    `json:"m2"`
 }
 
-type keyOverlayButton struct {
-	IsPressed bool  `json:"isPressed"`
-	Count     int32 `json:"count"`
+type keyCount struct {
+	K1 int32 `json:"k1"`
+	K2 int32 `json:"k2"`
+	M1 int32 `json:"m1"`
+	M2 int32 `json:"m2"`
 }
 
 type bm struct {


### PR DESCRIPTION
Hi maintainers, this is my first try on golang. 
This pull request aims at providing current position of cursor while playing and optimize reading key status.

## JSON changes
```go
//GameplayValues inside osu!memory
type GameplayValues struct {
	///...
        // previously keyOverlay, now changed to keyCount
        // because key status is moved to hitEvent
	KeyCount    keyCount    `json:"keyCount"`
        // hitEvent array
	HitEvent    []hitEvent  `json:"hitEvents"`
	//...
}

// this is one hit event frame
type hitEvent struct {
	X         float32 `json:"x"` // current x position
	Y         float32 `json:"y"` // current y position
	TimeStamp int32   `json:"timeStamp"` // current game time stamp
	K1        bool    `json:"k1"` // k1 pressed
	K2        bool    `json:"k2"` // k2 pressed
	M1        bool    `json:"m1"` // m1 pressed
	M2        bool    `json:"m2"` // k2 pressed
}

// keyCount uses previous way to read
type keyCount struct {
	K1 int32 `json:"k1"`
	K2 int32 `json:"k2"`
	M1 int32 `json:"m1"`
	M2 int32 `json:"m2"`
}
```

The `hitEvent` loads hit event frames from last UpdateTime to current time, about 7 to 15 frames.
`X` and `Y` is the position in game hit window, same as the replay frames in `.osr` files.

## How I read
I read these data from game frame memory. This area of memory may have different signature pattern, so I doesn't uses pattern defination like `sig:"xx xx"` or `mem:"[xx]"` to read. 
I just defined the signature in [`resolveHitEventAddress()`](https://github.com/StageGuard/gosumemory/commit/90cbc31db3c9696ce2bd69247d77a0bd4ac677d8#diff-b1dfb79371d0292a0ac17a4073f2456c3bd7b7ff624b3eb12ca5ca18b3b81143R84) function.

When playing, frame count of hit event in memory increased following game time, while watching replay, the frames all loads to memory at the start. 
So I maintain [`var hitEventFrame []hitEvent`](https://github.com/StageGuard/gosumemory/commit/90cbc31db3c9696ce2bd69247d77a0bd4ac677d8#diff-b1dfb79371d0292a0ac17a4073f2456c3bd7b7ff624b3eb12ca5ca18b3b81143R60) to tempory store frames. At every UpdateTime, it will decide which slice to return based on the current game time and the previous game time. Code at [here](https://github.com/StageGuard/gosumemory/commit/90cbc31db3c9696ce2bd69247d77a0bd4ac677d8#diff-b1dfb79371d0292a0ac17a4073f2456c3bd7b7ff624b3eb12ca5ca18b3b81143R432).

## Optimize key status
When reading this part of memory, I found that the hit event frames in memory also records key status. This block of memory is next to cursor position. 
So I removed previous way of reading key status and introduced a new way here btw.

## Game Mode compatibility
X and Y position works in all modes.
* In std: as mentioned above.
* In taiko: if X equals to `0`, means pressed left side key, `320` means none keys pressed, `640` means pressed right side key.
* In ctb: X is the position of catcher, ranging from `0` to `512`.
* In mania: X is bit flags of every track, like `0101` or `1111` in 4k.
Also works either single and multiplayer mode.

## More functions
* We can get play mode while playing(wathing replay or playing?) by detecting size changes of `hitEventFrame` just like [this if-else branch](https://github.com/StageGuard/gosumemory/commit/90cbc31db3c9696ce2bd69247d77a0bd4ac677d8#diff-b1dfb79371d0292a0ac17a4073f2456c3bd7b7ff624b3eb12ca5ca18b3b81143R432), so maybe we can add `PlayMode` field to `GameplayValues` to show if player watching replay or playing.
* We can also define a key counter to record pressed counts by key status, So we need not to rewrite key overlay anymore.