### PR TITLE
workaround: trimming extra space in beatmap folder name

### DIFF
--- a/memory/functions.go
+++ b/memory/functions.go
@@ -222,6 +222,7 @@ func bmUpdateData() error {
 		MenuData.GameMode = menuData.MenuGameMode
 		MenuData.Bm.RandkedStatus = menuData.RankedStatus
 		MenuData.Bm.BeatmapMD5 = menuData.MD5
+		menuData.Folder = strings.TrimSuffix(menuData.Folder, " ")
 		MenuData.Bm.Path = path{
 			AudioPath:            menuData.AudioFilename,
 			BGPath:               menuData.BackgroundFilename,

--- a/memory/init.go
+++ b/memory/init.go
@@ -145,7 +145,7 @@ func initBase() error {
 	if cast.ToBool(config.Config["enabled"]) {
 		err = injctr.Injct(process.Pid())
 		if err != nil {
-			log.Printf("Failed to inject into osu's process, in game overlay will be unavailabe. %e\n", err)
+			log.Printf("Failed to inject into osu's process, in game overlay will be unavailable. %e\n", err)
 		}
 	} else {
 		fmt.Println("[MEMORY] In-Game overlay is disabled, but could be enabled in config.ini!")


### PR DESCRIPTION
In some cases beatmap folder name contains extra space, so gosumemory cannot open the file:
![изображение](https://user-images.githubusercontent.com/57511281/200143400-9170368c-60b8-4cf9-9f6b-9ed6449825e1.png)

In osu!.db this extra space also present: [[map](https://osu.ppy.sh/beatmapsets/1140209)]
![изображение](https://user-images.githubusercontent.com/57511281/200143474-7de36e57-f67f-4620-9e82-c1ed162badba.png)

Another example: [[map](https://osu.ppy.sh/beatmapsets/416949)]
![изображение](https://user-images.githubusercontent.com/57511281/200143570-a2a09b92-1a60-4b19-9991-b1c9ce2b7fca.png)


