### PR TITLE
update ScoreV2 address offset

### DIFF
--- a/memory/read.go
+++ b/memory/read.go
@@ -135,7 +135,7 @@ type gameplayD struct {
 	Mode                int32   `mem:"[[Ruleset + 0x68] + 0x38] + 0x64"`
 	MaxCombo            int16   `mem:"[[Ruleset + 0x68] + 0x38] + 0x68"`
 	Score               int32   `mem:"[[Ruleset + 0x68] + 0x38] + 0x78"`
-	ScoreV2             int32   `mem:"Ruleset + 0xF8"`
+	ScoreV2             int32   `mem:"Ruleset + 0x100"`
 	Hit100              int16   `mem:"[[Ruleset + 0x68] + 0x38] + 0x88"`
 	Hit300              int16   `mem:"[[Ruleset + 0x68] + 0x38] + 0x8A"`
 	Hit50               int16   `mem:"[[Ruleset + 0x68] + 0x38] + 0x8C"`


### PR DESCRIPTION
Old offset always read `-1` for ScoreV2