### PR TITLE
Mention dotnet45 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ When operating in tourney mode, real-time pp counters for each client, leaderboa
 
 # Linux
 
-You have two options. Either run native, but with sudo privileges, or through WINE. Make sure to have dotnet45 installed, otherwise gosumemory won't be able to find the correct memory addesses.
+You have two options. Either run native, but with sudo privileges, or through WINE. Make sure to have dotnet45 installed, otherwise gosumemory won't be able to find the correct memory addresses.
 Please note that Linux builds are not well tested and could contain crashes. Report them if you encounter any.
 
 # Consider supporting

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ When operating in tourney mode, real-time pp counters for each client, leaderboa
 
 # Linux
 
-You have two options. Either run native, but with sudo privileges, or through WINE.
+You have two options. Either run native, but with sudo privileges, or through WINE. Make sure to have dotnet45 installed, otherwise gosumemory won't be able to find the correct memory addesses.
 Please note that Linux builds are not well tested and could contain crashes. Report them if you encounter any.
 
 # Consider supporting


### PR DESCRIPTION
When running osu under wine on linux it needs to have dotnet45 installed otherwise the memory addresses will be wrong. Had to find this out the hard way, so I figured it might be worth to mention it in the readme so others don't have to go through the same struggles. :sweat_smile: 